### PR TITLE
add an optional backtrace (if DEBUG=1 is set in ENV) in case of exception

### DIFF
--- a/lib/synvert/cli.rb
+++ b/lib/synvert/cli.rb
@@ -51,6 +51,7 @@ module Synvert
     rescue Exception => e
       print "Error: "
       p e
+      puts e.backtrace.join("\n") if ENV['DEBUG']
       false
     end
 


### PR DESCRIPTION
I had a `Error: #<ArgumentError: invalid byte sequence in UTF-8>` with `upgrade_rails_3_2_to_4_0` snippet and wondered why, so I added that backtrace. For example:

```
4:28 ⮀ mobox ⮀ ~/projects/agitracker ⮀ bundle exec synvert -s upgrade_rails_3_2_to_4_0                                                                                                ⮂ ⭠ master ✗ 
Error: #<ArgumentError: invalid byte sequence in UTF-8>

 4:28 ⮀ mobox ⮀ ~/projects/agitracker ⮀ DEBUG=1 bundle exec synvert -s upgrade_rails_3_2_to_4_0                                                                                        ⮂ ⭠ master ✗ 
Error: #<ArgumentError: invalid byte sequence in UTF-8>
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/parser-2.1.9/lib/parser/source/buffer.rb:171:in `gsub'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/parser-2.1.9/lib/parser/source/buffer.rb:171:in `raw_source='
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/parser-2.1.9/lib/parser/source/buffer.rb:156:in `source='
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/synvert-core-0.1.1/lib/synvert/core/rewriter/instance.rb:39:in `block in process'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/synvert-core-0.1.1/lib/synvert/core/rewriter/instance.rb:34:in `each'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/synvert-core-0.1.1/lib/synvert/core/rewriter/instance.rb:34:in `process'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/synvert-core-0.1.1/lib/synvert/core/rewriter.rb:153:in `within_files'
(eval):24:in `block (2 levels) in load_rewriters'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/synvert-core-0.1.1/lib/synvert/core/rewriter.rb:105:in `instance_eval'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/synvert-core-0.1.1/lib/synvert/core/rewriter.rb:105:in `process'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/synvert-core-0.1.1/lib/synvert/core/rewriter.rb:62:in `call'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/synvert-core-0.1.1/lib/synvert/core/rewriter.rb:176:in `add_snippet'
(eval):219:in `block (2 levels) in load_rewriters'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/synvert-core-0.1.1/lib/synvert/core/rewriter.rb:105:in `instance_eval'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/synvert-core-0.1.1/lib/synvert/core/rewriter.rb:105:in `process'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/gems/synvert-core-0.1.1/lib/synvert/core/rewriter.rb:112:in `process_with_sandbox'
/home/mose/projects/synvert/lib/synvert/cli.rb:144:in `show_rewriter'
/home/mose/projects/synvert/lib/synvert/cli.rb:33:in `run'
/home/mose/projects/synvert/lib/synvert/cli.rb:13:in `run'
/home/mose/projects/synvert/bin/synvert:7:in `<top (required)>'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/bin/synvert:23:in `load'
/home/mose/projects/agitracker/vendor/ruby/1.9.1/bin/synvert:23:in `<main>'
```
