### PR TITLE
Auto corrected by following Lint Ruby Style/RescueStandardError

### DIFF
--- a/lib/synvert/cli.rb
+++ b/lib/synvert/cli.rb
@@ -125,7 +125,7 @@ module Synvert
           require snippet_path
         end
       end
-    rescue
+    rescue StandardError
       FileUtils.rm_rf default_snippets_path
       retry
     end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/RescueStandardError

Click [here](https://awesomecode.io/repos/xinminlabs/synvert/lint_configs/ruby/104916) to configure it on awesomecode.io